### PR TITLE
feature(fabric8): Add fabric8 to be able to deploy onto openshift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,10 @@
     <jacoco.version>0.8.6</jacoco.version>
     <nohttp-checkstyle.version>0.0.4.RELEASE</nohttp-checkstyle.version>
     <spring-format.version>0.0.19</spring-format.version>
+    <openjdk18-openshift.version>1.3</openjdk18-openshift.version>
+    <fabric8.generator.from>
+      registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${openjdk18-openshift.version}
+    </fabric8.generator.from>
   </properties>
 
   <dependencies>
@@ -375,6 +379,26 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>openshift</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>fabric8-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>fmp</id>
+                <goals>
+                  <goal>resource</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
Include Fabric8 to be able to deploy to OpenShift.

Update based off the CRW samples:
https://github.com/crw-samples/rest-http-example/blob/master/pom.xml

Makes this particularly nice in the context of CodeReady Workspaces.

```
mvn fabric8:deploy -Popenshift
```